### PR TITLE
Adding user display name to expense info

### DIFF
--- a/app/src/main/java/com/section11/expenselens/data/dto/FirestoreExpense.kt
+++ b/app/src/main/java/com/section11/expenselens/data/dto/FirestoreExpense.kt
@@ -10,6 +10,7 @@ data class FirestoreExpense(
     val total: Double = 0.0,
     val date: Timestamp = Timestamp.now(),
     val userId: String = "",
+    val userDisplayName: String? = "",
     val note: String? = null,
     val distributedExpense: Map<String, Double>? = null
 )

--- a/app/src/main/java/com/section11/expenselens/data/repository/FirestoreExpensesRepository.kt
+++ b/app/src/main/java/com/section11/expenselens/data/repository/FirestoreExpensesRepository.kt
@@ -9,6 +9,7 @@ import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.data.dto.FirestoreHousehold
 import com.section11.expenselens.data.dto.FirestoreHousehold.Companion.NAME_FIELD
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
+import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.repository.ExpensesRepository
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
@@ -61,13 +62,13 @@ class FirestoreExpensesRepository @Inject constructor(
 
             Result.success(householdId to householdName)
         } catch (exception: FirebaseFirestoreException) {
-            Log.e("FirebaseFirestoreException", exception.stackTraceToString())
+            Log.e(FirebaseFirestoreException::class.simpleName, exception.stackTraceToString())
             Result.failure(exception)
         }
     }
 
     override suspend fun addExpenseToHousehold(
-        userId: String,
+        userData: UserData,
         householdId: String,
         expense: ConsolidatedExpenseInformation
     ): Result<Unit> {
@@ -75,7 +76,8 @@ class FirestoreExpensesRepository @Inject constructor(
             total = expense.total,
             category = expense.category.displayName,
             date = Timestamp(expense.date),
-            userId = userId,
+            userId = userData.id,
+            userDisplayName = userData.displayName,
             note = expense.note,
             distributedExpense = expense.distributedExpense
         )

--- a/app/src/main/java/com/section11/expenselens/domain/repository/ExpensesRepository.kt
+++ b/app/src/main/java/com/section11/expenselens/domain/repository/ExpensesRepository.kt
@@ -2,6 +2,7 @@ package com.section11.expenselens.domain.repository
 
 import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
+import com.section11.expenselens.domain.models.UserData
 
 interface ExpensesRepository {
 
@@ -10,7 +11,7 @@ interface ExpensesRepository {
     suspend fun createHousehold(householdName: String, userId: String): Result<Pair<String, String>>
 
     suspend fun addExpenseToHousehold(
-        userId: String,
+        userData: UserData,
         householdId: String,
         expense: ConsolidatedExpenseInformation
     ): Result<Unit>

--- a/app/src/main/java/com/section11/expenselens/domain/usecase/StoreExpenseUseCase.kt
+++ b/app/src/main/java/com/section11/expenselens/domain/usecase/StoreExpenseUseCase.kt
@@ -3,6 +3,7 @@ package com.section11.expenselens.domain.usecase
 import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.domain.exceptions.HouseholdNotFoundException
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
+import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.repository.ExpensesRepository
 import javax.inject.Inject
 
@@ -28,7 +29,7 @@ class StoreExpenseUseCase @Inject constructor(
     }
 
     suspend fun addExpense(
-        userId: String,
+        userData: UserData,
         expense: ConsolidatedExpenseInformation,
         householdId: String? = null
     ): Result<Unit> {
@@ -37,7 +38,7 @@ class StoreExpenseUseCase @Inject constructor(
             currentHouseholdId = expensesRepository.getHousehold(TEST_HOUSEHOLD_NAME)
             currentHouseholdId ?: return Result.failure(HouseholdNotFoundException())
         }
-        return expensesRepository.addExpenseToHousehold(userId, currentHouseholdId, expense)
+        return expensesRepository.addExpenseToHousehold(userData, currentHouseholdId, expense)
     }
 
     suspend fun getAllExpensesFromHousehold(householdId: String): Result<List<FirestoreExpense>> {

--- a/app/src/main/java/com/section11/expenselens/ui/history/composables/ExpensesHistoryScreen.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/history/composables/ExpensesHistoryScreen.kt
@@ -67,6 +67,13 @@ fun ExpenseItem(expense: FirestoreExpense) {
             text = "Date: ${expense.date.toFormattedString()}",
             style = MaterialTheme.typography.bodySmall
         )
+        expense.userDisplayName?.let { userName ->
+            Text(
+                text = "Submitted by: $userName",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
         expense.note?.let {
             Text(
                 text = "Note: $it",

--- a/app/src/main/java/com/section11/expenselens/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/HomeViewModel.kt
@@ -3,7 +3,6 @@ package com.section11.expenselens.ui.home
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase.SignInResult.SignInCancelled
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase.SignInResult.SignInSuccess
@@ -41,7 +40,6 @@ class HomeViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     private val googleSignInUseCase: GoogleSignInUseCase,
     private val storeExpenseUseCase: StoreExpenseUseCase,
-    private val firebaseAuth: FirebaseAuth,
     private val mapper: HomeScreenUiMapper,
     private val dispatcher: CoroutineDispatcher
 ) : ViewModel() {
@@ -58,9 +56,8 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch(dispatcher) {
             _uiEvent.emit(Loading(true))
             val userData = googleSignInUseCase.getCurrentUser().getOrNull()
-            val user = firebaseAuth.currentUser
-            if (userData != null && user?.uid != null) {
-                val householdResult = storeExpenseUseCase.getCurrentHouseholdIdAndName(user.uid)
+            if (userData != null) {
+                val householdResult = storeExpenseUseCase.getCurrentHouseholdIdAndName(userData.id)
                 val householdName = householdResult.getOrNull()?.second
                 val userUiModel = mapper.getUserData(userData)
                 _uiState.value = UserSignedIn(greeting, userUiModel, householdName)

--- a/app/src/main/java/com/section11/expenselens/ui/review/ExpenseReviewViewModel.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/review/ExpenseReviewViewModel.kt
@@ -2,8 +2,8 @@ package com.section11.expenselens.ui.review
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
 import com.section11.expenselens.domain.models.SuggestedExpenseInformation
+import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
 import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
 import com.section11.expenselens.framework.navigation.NavigationManager
 import com.section11.expenselens.framework.navigation.NavigationManager.NavigationEvent.NavigateHome
@@ -39,7 +39,7 @@ private const val SUBMIT_EXPENSE_ERROR = "Couldn't submit expense, try again lat
 class ExpenseReviewViewModel @Inject constructor(
     private val expenseReviewUiMapper: ExpenseReviewScreenUiMapper,
     private val storeExpenseUseCase: StoreExpenseUseCase,
-    private val firebaseAuth: FirebaseAuth,
+    private val signInUseCase: GoogleSignInUseCase,
     private val navigationManager: NavigationManager,
     private val dispatcher: CoroutineDispatcher
 ) : ViewModel() {
@@ -61,10 +61,10 @@ class ExpenseReviewViewModel @Inject constructor(
             is ExpenseSubmitted -> {
                 viewModelScope.launch(dispatcher) {
                     _uiEvent.emit(Loading(true))
-                    val userId = firebaseAuth.currentUser?.uid
-                    if (userId != null) {
+                    val user = signInUseCase.getCurrentUser().getOrNull()
+                    if (user != null) {
                         val expense = expenseReviewUiMapper.toConsolidatedExpense(event)
-                        val result = storeExpenseUseCase.addExpense(userId, expense)
+                        val result = storeExpenseUseCase.addExpense(user, expense)
                         _uiEvent.emit(Loading(false))
                         handleExpenseSubmission(result)
                     } else {

--- a/app/src/test/java/com/section11/expenselens/data/repository/FirestoreExpensesRepositoryTest.kt
+++ b/app/src/test/java/com/section11/expenselens/data/repository/FirestoreExpensesRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.data.dto.FirestoreHousehold.Companion.NAME_FIELD
 import com.section11.expenselens.domain.models.Category.HOME
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
+import com.section11.expenselens.domain.models.UserData
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -103,7 +104,11 @@ class FirestoreExpensesRepositoryTest {
     @Test
     fun `addExpenseToHousehold returns success when added successfully`() = runTest {
         // Given
+        val userData: UserData = mock()
         val userId = "user123"
+        val userName = "username"
+        whenever(userData.id).thenReturn(userId)
+        whenever(userData.displayName).thenReturn(userName)
         val householdId = "household456"
         val expense = ConsolidatedExpenseInformation(
             total = 100.0,
@@ -123,7 +128,7 @@ class FirestoreExpensesRepositoryTest {
         whenever(mockCollection.add(any())).thenReturn(mockTask)
 
         // When
-        val result = repository.addExpenseToHousehold(userId, householdId, expense)
+        val result = repository.addExpenseToHousehold(userData, householdId, expense)
 
         // Then
         assertTrue(result.isSuccess)

--- a/app/src/test/java/com/section11/expenselens/domain/usecase/StoreExpenseUseCaseTest.kt
+++ b/app/src/test/java/com/section11/expenselens/domain/usecase/StoreExpenseUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.domain.exceptions.HouseholdNotFoundException
 import com.section11.expenselens.domain.models.Category.HOME
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
+import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.repository.ExpensesRepository
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
@@ -66,6 +67,9 @@ class StoreExpenseUseCaseTest {
     fun `addExpense successfully adds expense when household ID is provided`() = runTest {
         // Given
         val userId = "user123"
+        val userMock: UserData = mock()
+        whenever(userMock.id).thenReturn(userId)
+        whenever(userMock.displayName).thenReturn("Test User")
         val householdId = "household456"
         val expense = ConsolidatedExpenseInformation(
             total = 100.0,
@@ -75,11 +79,11 @@ class StoreExpenseUseCaseTest {
             distributedExpense = mapOf(userId to 50.0)
         )
 
-        whenever(mockRepository.addExpenseToHousehold(userId, householdId, expense))
+        whenever(mockRepository.addExpenseToHousehold(userMock, householdId, expense))
             .thenReturn(Result.success(Unit))
 
         // When
-        val result = useCase.addExpense(userId, expense, householdId)
+        val result = useCase.addExpense(userMock, expense, householdId)
 
         // Then
         assertTrue(result.isSuccess)
@@ -89,6 +93,9 @@ class StoreExpenseUseCaseTest {
     fun `addExpense retrieves household ID before adding expense`() = runTest {
         // Given
         val userId = "user123"
+        val userMock: UserData = mock()
+        whenever(userMock.id).thenReturn(userId)
+        whenever(userMock.displayName).thenReturn("Test User")
         val householdId = "household456"
         val expense = ConsolidatedExpenseInformation(
             total = 100.0,
@@ -99,11 +106,11 @@ class StoreExpenseUseCaseTest {
         )
 
         whenever(mockRepository.getHousehold(TEST_HOUSEHOLD_NAME)).thenReturn(householdId)
-        whenever(mockRepository.addExpenseToHousehold(userId, householdId, expense))
+        whenever(mockRepository.addExpenseToHousehold(userMock, householdId, expense))
             .thenReturn(Result.success(Unit))
 
         // When
-        val result = useCase.addExpense(userId, expense)
+        val result = useCase.addExpense(userMock, expense)
 
         // Then
         assertTrue(result.isSuccess)
@@ -114,6 +121,9 @@ class StoreExpenseUseCaseTest {
     fun `addExpense fails if no household is found`() = runTest {
         // Given
         val userId = "user123"
+        val userMock: UserData = mock()
+        whenever(userMock.id).thenReturn(userId)
+        whenever(userMock.displayName).thenReturn("Test User")
         val expense = ConsolidatedExpenseInformation(
             total = 100.0,
             category = HOME,
@@ -125,7 +135,7 @@ class StoreExpenseUseCaseTest {
         whenever(mockRepository.getHousehold(TEST_HOUSEHOLD_NAME)).thenReturn(null)
 
         // When
-        val result = useCase.addExpense(userId, expense)
+        val result = useCase.addExpense(userMock, expense)
 
         // Then
         assertTrue(result.isFailure)

--- a/app/src/test/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModelTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModelTest.kt
@@ -1,9 +1,8 @@
 package com.section11.expenselens.ui.history
 
-
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.section11.expenselens.data.dto.FirestoreExpense
+import com.section11.expenselens.domain.models.UserData
+import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
 import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,15 +24,17 @@ class ExpenseHistoryViewModelTest {
 
     private lateinit var viewModel: ExpenseHistoryViewModel
     private val storeExpensesUseCase: StoreExpenseUseCase = mock()
-    private val firebaseAuth: FirebaseAuth = mock()
-    private val firebaseUser: FirebaseUser = mock()
+    private val signInUseCase: GoogleSignInUseCase = mock()
+    private val userData: UserData = mock()
     private val dispatcher = StandardTestDispatcher()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        whenever(firebaseAuth.currentUser).thenReturn(firebaseUser)
-        whenever(firebaseUser.uid).thenReturn("user123")
+        whenever(userData.id).thenReturn("user123")
+        runTest {
+            whenever(signInUseCase.getCurrentUser()).thenReturn(Result.success(userData))
+        }
     }
 
     @After
@@ -56,7 +57,7 @@ class ExpenseHistoryViewModelTest {
             .thenReturn(Result.success(expenses))
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, firebaseAuth, dispatcher)
+        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then
@@ -70,7 +71,7 @@ class ExpenseHistoryViewModelTest {
             .thenReturn(Result.failure(Exception("Household not found")))
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, firebaseAuth, dispatcher)
+        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then
@@ -80,10 +81,10 @@ class ExpenseHistoryViewModelTest {
     @Test
     fun `uiState remains empty when user is null`() = runTest {
         // Given
-        whenever(firebaseAuth.currentUser).thenReturn(null)
+        whenever(signInUseCase.getCurrentUser()).thenReturn(null)
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, firebaseAuth, dispatcher)
+        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then

--- a/app/src/test/java/com/section11/expenselens/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/home/HomeViewModelTest.kt
@@ -1,8 +1,6 @@
 package com.section11.expenselens.ui.home
 
 import android.content.Context
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase.SignInResult.SignInCancelled
@@ -48,7 +46,6 @@ class HomeViewModelTest {
     private val mapper: HomeScreenUiMapper = mock()
     private val googleSignInUseCase: GoogleSignInUseCase = mock()
     private val storeExpenseUseCase: StoreExpenseUseCase = mock()
-    private val firebaseAuth: FirebaseAuth  = mock()
     private val greeting = "hello"
 
     private lateinit var viewModel: HomeViewModel
@@ -61,7 +58,6 @@ class HomeViewModelTest {
             navigationManager,
             googleSignInUseCase,
             storeExpenseUseCase,
-            firebaseAuth,
             mapper,
             testDispatcher
         )
@@ -78,15 +74,14 @@ class HomeViewModelTest {
         whenever(googleSignInUseCase.getCurrentUser()).thenReturn(Result.success(mockUserData))
         val mockUiModel: UserInfoUiModel = mock()
         whenever(mapper.getUserData(any())).thenReturn(mockUiModel)
-        val firebaseUser: FirebaseUser = mock()
-        whenever(firebaseUser.uid).thenReturn("uid")
-        whenever(firebaseAuth.currentUser).thenReturn(firebaseUser)
+        val user: UserData = mock()
+        whenever(user.id).thenReturn("uid")
+        whenever(googleSignInUseCase.getCurrentUser()).thenReturn(Result.success(user))
 
         viewModel = HomeViewModel(
             navigationManager,
             googleSignInUseCase,
             storeExpenseUseCase,
-            firebaseAuth,
             mapper,
             testDispatcher
         )
@@ -103,7 +98,6 @@ class HomeViewModelTest {
             navigationManager,
             googleSignInUseCase,
             storeExpenseUseCase,
-            firebaseAuth,
             mapper,
             testDispatcher
         )
@@ -118,15 +112,14 @@ class HomeViewModelTest {
         whenever(googleSignInUseCase.getCurrentUser()).thenReturn(Result.success(mockUserData))
         val mockUiModel: UserInfoUiModel = mock()
         whenever(mapper.getUserData(any())).thenReturn(mockUiModel)
-        val firebaseUser: FirebaseUser = mock()
-        whenever(firebaseUser.uid).thenReturn("uid")
-        whenever(firebaseAuth.currentUser).thenReturn(firebaseUser)
+        val user: UserData = mock()
+        whenever(user.id).thenReturn("uid")
+        whenever(googleSignInUseCase.getCurrentUser()).thenReturn(Result.success(user))
 
         viewModel = HomeViewModel(
             navigationManager,
             googleSignInUseCase,
             storeExpenseUseCase,
-            firebaseAuth,
             mapper,
             testDispatcher
         )


### PR DESCRIPTION
- Refactored how we were getting the userId, now its being fetched from the userData in our local repo, instead from FirebaseAuth each time
- Added optional submitted by, which should be there unless the user has no username/display name