### PR TITLE
Added invite accept or refuse functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,7 @@ dependencies {
     testImplementation(libs.mockk.agent)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.google.truth)
+    testImplementation(libs.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/config/detekt/detekt.yml
+++ b/app/config/detekt/detekt.yml
@@ -132,7 +132,7 @@ complexity:
   LongParameterList:
     active: true
     functionThreshold: 7
-    constructorThreshold: 7
+    constructorThreshold: 8
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []

--- a/app/src/androidTest/kotlin/com/section11/expenselens/ui/common/EventHandlerKtTest.kt
+++ b/app/src/androidTest/kotlin/com/section11/expenselens/ui/common/EventHandlerKtTest.kt
@@ -1,0 +1,76 @@
+package com.section11.expenselens.ui.common
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.section11.expenselens.ui.utils.DownstreamUiEvent
+import com.section11.expenselens.ui.utils.DownstreamUiEvent.Loading
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class EventHandlerKtTestTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenLoadingEventIsTrue_loaderIsDisplayed() = runTest {
+        // Given
+        val downstreamUiEvent = MutableSharedFlow<DownstreamUiEvent>()
+        composeTestRule.setContent {
+            HandleDownstreamEvents(
+                downstreamUiEvent = downstreamUiEvent,
+                modifier = Modifier.testTag("loader")
+            )
+        }
+
+        // When
+        downstreamUiEvent.emit(Loading(isLoading = true))
+        composeTestRule.waitForIdle()
+
+        // Then
+        composeTestRule.onNodeWithTag("loader").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenLoadingEventIsFalse_loaderIsNotDisplayed() = runTest {
+        // Given
+        val downstreamUiEvent = MutableSharedFlow<DownstreamUiEvent>()
+        composeTestRule.setContent {
+            HandleDownstreamEvents(
+                downstreamUiEvent = downstreamUiEvent,
+                modifier = Modifier.testTag("loader")
+            )
+        }
+
+        // When
+        downstreamUiEvent.emit(Loading(isLoading = false))
+        composeTestRule.waitForIdle()
+
+        // Then
+        composeTestRule.onNodeWithTag("loader").assertDoesNotExist()
+    }
+
+    @Test
+    fun whenNoEventEmitted_loaderIsNotDisplayed() = runTest {
+        // Given
+        val downstreamUiEvent = MutableSharedFlow<DownstreamUiEvent>()
+        composeTestRule.setContent {
+            HandleDownstreamEvents(
+                downstreamUiEvent = downstreamUiEvent,
+                modifier = Modifier.testTag("loader")
+            )
+        }
+
+        // When
+        composeTestRule.waitForIdle()
+
+        // Then
+        composeTestRule.onNodeWithTag("loader").assertIsNotDisplayed()
+    }
+}

--- a/app/src/main/java/com/section11/expenselens/data/constants/FirestoreConstants.kt
+++ b/app/src/main/java/com/section11/expenselens/data/constants/FirestoreConstants.kt
@@ -6,12 +6,18 @@ package com.section11.expenselens.data.constants
  *      - users/{userId} (collection)
  *          - email
  *          - households (list of households)
+ *              - id
+ *              - name
  *          - invitations (list of invitations)
  *              - householdId
  *              - householdName
  *              - inviterId
  *              - status (pending, accepted, rejected)
+ *              - timestamp
  *      - households/{householdId} (collection)
+ *              - id
+ *              - name
+ *              - users
  *              - expenses
  *                  - expenseId
  *                  - category
@@ -27,19 +33,45 @@ object FirestoreConstants {
     object Collections {
         const val USERS_COLLECTION = "users"
         const val HOUSEHOLDS_COLLECTION = "households"
-        const val EXPENSES_COLLECTION = "expenses"
-    }
 
-    object Fields {
-        const val HOUSEHOLDS_FIELD = "households"  // Field inside `users/{userId}`
-        const val HOUSEHOLD_ID_FIELD = "householdId"
-        const val HOUSEHOLD_NAME_FIELD = "householdName"
-        const val INVITATIONS_FIELD = "invitations"
-        const val INVITER_ID_FIELD = "inviterId"
-        const val INVITE_STATUS_FIELD = "status"
-        const val INVITE_TIMESTAMP_FIELD = "timestamp"
-        const val ID_FIELD = "id"
-        const val NAME_FIELD = "name"
-        const val EMAIL_FIELD = "email"
+        object UsersCollection {
+            const val EMAIL_FIELD = "email"
+            const val HOUSEHOLDS_FIELD = "households"
+            const val INVITATIONS_FIELD = "invitations"
+
+            object UsersHouseholdsArray {
+                const val HOUSEHOLD_ID_FIELD = "id"
+                const val HOUSEHOLD_NAME_FIELD = "name"
+            }
+
+            object UsersInvitationsArray {
+                const val INVITER_ID = "inviterId"
+                const val INVITE_STATUS = "status"
+                const val INVITE_TIMESTAMP = "timestamp"
+                const val INVITE_HOUSEHOLD_ID = "householdId"
+                const val INVITE_HOUSEHOLD_NAME = "householdName"
+            }
+        }
+
+        /**
+         * Commented Fields are not being used right now. But will be used in the future. Thats how
+         * the structure should be.
+         */
+        object HouseholdsCollection {
+            const val USERS_FIELD = "users"
+            const val EXPENSES_FIELD = "expenses"
+//            const val ID_FIELD = "id"
+//            const val NAME_FIELD = "name"
+
+//            object ExpensesArray {
+//                const val EXPENSE_ID_FIELD = "expenseId"
+//                const val CATEGORY_FIELD = "category"
+//                const val TOTAL_FIELD = "total"
+//                const val DATE_FIELD = "date"
+//                const val USER_ID_FIELD = "userId"
+//                const val USER_DISPLAY_NAME_FIELD = "userDisplayName"
+//                const val NOTE_FIELD = "note"
+//            }
+        }
     }
 }

--- a/app/src/main/java/com/section11/expenselens/data/mapper/HouseholdMapper.kt
+++ b/app/src/main/java/com/section11/expenselens/data/mapper/HouseholdMapper.kt
@@ -1,0 +1,14 @@
+package com.section11.expenselens.data.mapper
+
+import com.section11.expenselens.data.constants.FirestoreConstants.Collections.UsersCollection.UsersHouseholdsArray.HOUSEHOLD_ID_FIELD
+import com.section11.expenselens.data.constants.FirestoreConstants.Collections.UsersCollection.UsersHouseholdsArray.HOUSEHOLD_NAME_FIELD
+import com.section11.expenselens.domain.models.UserHousehold
+
+fun List<*>.mapToHouseholdsList(): List<UserHousehold> {
+    return mapNotNull {
+        val map = it as? Map<*, *>
+        val id = map?.get(HOUSEHOLD_ID_FIELD) as? String
+        val name = map?.get(HOUSEHOLD_NAME_FIELD) as? String
+        if (id != null && name != null) UserHousehold(id, name) else null
+    }
+}

--- a/app/src/main/java/com/section11/expenselens/data/repository/FirestoreHouseholdRepository.kt
+++ b/app/src/main/java/com/section11/expenselens/data/repository/FirestoreHouseholdRepository.kt
@@ -4,20 +4,20 @@ import android.util.Log
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
-import com.section11.expenselens.data.constants.FirestoreConstants.Collections.EXPENSES_COLLECTION
 import com.section11.expenselens.data.constants.FirestoreConstants.Collections.HOUSEHOLDS_COLLECTION
+import com.section11.expenselens.data.constants.FirestoreConstants.Collections.HouseholdsCollection.EXPENSES_FIELD
 import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.data.dto.FirestoreHousehold
 import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.models.UserHousehold
-import com.section11.expenselens.domain.repository.ExpensesRepository
+import com.section11.expenselens.domain.repository.HouseholdRepository
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-class FirestoreExpensesRepository @Inject constructor(
+class FirestoreHouseholdRepository @Inject constructor(
     private val firestore: FirebaseFirestore
-): ExpensesRepository {
+): HouseholdRepository {
 
     override suspend fun createHousehold(
         userId: String,
@@ -75,7 +75,7 @@ class FirestoreExpensesRepository @Inject constructor(
         return try {
             firestore.collection(HOUSEHOLDS_COLLECTION)
                 .document(householdId)
-                .collection(EXPENSES_COLLECTION)
+                .collection(EXPENSES_FIELD)
                 .add(firestoreExpense)
                 .await()
             Result.success(Unit)
@@ -90,7 +90,7 @@ class FirestoreExpensesRepository @Inject constructor(
         return try {
             val expensesCollection = firestore.collection(HOUSEHOLDS_COLLECTION)
                 .document(householdId)
-                .collection(EXPENSES_COLLECTION)
+                .collection(EXPENSES_FIELD)
 
             val querySnapshot = expensesCollection.get().await()
 

--- a/app/src/main/java/com/section11/expenselens/domain/repository/HouseholdInvitationRepository.kt
+++ b/app/src/main/java/com/section11/expenselens/domain/repository/HouseholdInvitationRepository.kt
@@ -12,4 +12,8 @@ interface HouseholdInvitationRepository {
     ) : Result<Unit>
 
     suspend fun getPendingInvitations(userId: String): Result<List<HouseholdInvite>>
+
+    suspend fun acceptHouseholdInvite(userId: String, householdId: String, householdName: String): Result<Unit>
+
+    suspend fun deleteHouseholdInvite(userId: String, householdId: String): Result<Unit>
 }

--- a/app/src/main/java/com/section11/expenselens/domain/repository/HouseholdRepository.kt
+++ b/app/src/main/java/com/section11/expenselens/domain/repository/HouseholdRepository.kt
@@ -5,7 +5,7 @@ import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.models.UserHousehold
 
-interface ExpensesRepository {
+interface HouseholdRepository {
 
     suspend fun createHousehold(userId: String, householdName: String): Result<UserHousehold>
 

--- a/app/src/main/java/com/section11/expenselens/domain/usecase/HouseholdInvitationUseCase.kt
+++ b/app/src/main/java/com/section11/expenselens/domain/usecase/HouseholdInvitationUseCase.kt
@@ -24,4 +24,19 @@ class HouseholdInvitationUseCase @Inject constructor(
     suspend fun getPendingInvitations(userId: String): Result<List<HouseholdInvite>> {
         return householdInvitationRepository.getPendingInvitations(userId)
     }
+
+    suspend fun handleHouseholdInviteResponse(
+        inviteWasAccepted: Boolean,
+        userId: String,
+        householdId: String,
+        householdName: String
+    ): Result<List<HouseholdInvite>> {
+        if (inviteWasAccepted) {
+            householdInvitationRepository.acceptHouseholdInvite(userId, householdId, householdName)
+        } else {
+            householdInvitationRepository.deleteHouseholdInvite(userId, householdId)
+        }
+
+        return getPendingInvitations(userId)
+    }
 }

--- a/app/src/main/java/com/section11/expenselens/framework/di/RepositoryModule.kt
+++ b/app/src/main/java/com/section11/expenselens/framework/di/RepositoryModule.kt
@@ -6,14 +6,14 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.gson.Gson
 import com.section11.expenselens.BuildConfig
 import com.section11.expenselens.data.mapper.GeminiResponseMapper
-import com.section11.expenselens.data.repository.FirestoreExpensesRepository
+import com.section11.expenselens.data.repository.FirestoreHouseholdRepository
 import com.section11.expenselens.data.repository.FirestoreHouseholdInvitationRepository
 import com.section11.expenselens.data.repository.FirestoreUsersCollectionRepository
 import com.section11.expenselens.data.repository.GeminiAiRepository
 import com.section11.expenselens.data.repository.GoogleUserSessionRepository
 import com.section11.expenselens.data.service.GeminiService
 import com.section11.expenselens.domain.repository.ExpenseInfoExtractorRepository
-import com.section11.expenselens.domain.repository.ExpensesRepository
+import com.section11.expenselens.domain.repository.HouseholdRepository
 import com.section11.expenselens.domain.repository.HouseholdInvitationRepository
 import com.section11.expenselens.domain.repository.UsersCollectionRepository
 import com.section11.expenselens.domain.repository.UserSessionRepository
@@ -55,8 +55,8 @@ class RepositoryModule {
     }
 
     @Provides
-    fun provideFirestoreExpensesRepository(firestore: FirebaseFirestore): ExpensesRepository {
-        return FirestoreExpensesRepository(firestore)
+    fun provideFirestoreExpensesRepository(firestore: FirebaseFirestore): HouseholdRepository {
+        return FirestoreHouseholdRepository(firestore)
     }
 
     @Provides

--- a/app/src/main/java/com/section11/expenselens/ui/common/previewrepository/FakeRepositoryForPreviews.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/common/previewrepository/FakeRepositoryForPreviews.kt
@@ -32,7 +32,7 @@ class FakeRepositoryForPreviews(context: Context) {
             pendingInvites = listOf(
                 PendingInvitesUiModel(
                     householdName = "Fake household",
-                    id = "id",
+                    householdId = "id",
                     status = InviteStatusUiModel.Pending,
                     timestamp = Timestamp.now()
             ))

--- a/app/src/main/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModel.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
-import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
+import com.section11.expenselens.domain.usecase.HouseholdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ExpenseHistoryViewModel @Inject constructor(
-    private val storeExpensesUseCase: StoreExpenseUseCase,
+    private val householdUseCase: HouseholdUseCase,
     private val useCase: GoogleSignInUseCase,
     dispatcher: CoroutineDispatcher
 ) : ViewModel() {
@@ -26,9 +26,9 @@ class ExpenseHistoryViewModel @Inject constructor(
         viewModelScope.launch(dispatcher) {
             val user = useCase.getCurrentUser().getOrNull()
             if (user != null) {
-                val household = storeExpensesUseCase.getCurrentHousehold(user.id)
+                val household = householdUseCase.getCurrentHousehold(user.id)
                 if (household != null) {
-                    val expenses = storeExpensesUseCase.getAllExpensesFromHousehold(household.id)
+                    val expenses = householdUseCase.getAllExpensesFromHousehold(household.id)
 
                     expenses.getOrNull()?.let { expensesList ->
                         _uiState.value = expensesList.map {

--- a/app/src/main/java/com/section11/expenselens/ui/home/composables/SignedInUi.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/composables/SignedInUi.kt
@@ -198,7 +198,7 @@ fun ProfileDialogContent(
             Spacer(Modifier.height(dimens.m1))
         }
 
-        PendingInvitesSection(userInfo.pendingInvites, onEvent)
+        PendingInvitesSection(userInfo.pendingInvites, userInfo.id, onEvent)
 
         Spacer(Modifier.height(dimens.m1))
     }
@@ -276,58 +276,79 @@ fun CreateHouseholdUi(
 @Composable
 fun PendingInvitesSection(
     pendingInvitesUiModel: List<PendingInvitesUiModel>,
+    userId: String,
     onEvent: (HomeUpstreamEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val dimens = LocalDimens.current
-    var isLoading by remember { mutableStateOf(false) }
 
-    if (pendingInvitesUiModel.isNotEmpty() && isLoading.not()) {
+    if (pendingInvitesUiModel.isNotEmpty()) {
         Column(
             modifier,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             pendingInvitesUiModel.forEach {
-                Row(
-                    Modifier.fillMaxWidth(1f),
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    Text(
-                        stringResource(R.string.profile_dialog_invitation_prefix, it.householdName),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-                Row(
-                    Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly
-                ) {
-                    Button(
-                        onClick = {
-                            isLoading = true
-                            onEvent(HouseholdInviteTap(it.id, true))
-                        }
-                    ) {
-                        Text(
-                            stringResource(R.string.profile_dialog_accept_invitation),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                    TextButton(
-                        onClick = {
-                            isLoading = true
-                            onEvent(HouseholdInviteTap(it.id, false))
-                        }
-                    ) {
-                        Text(
-                            stringResource(R.string.profile_dialog_reject_invitation),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
+                if (it.isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(dimens.m5))
+                } else {
+                    PendingInviteItem(it, userId, onEvent)
                 }
             }
         }
-    } else if (isLoading) {
-        CircularProgressIndicator(modifier = Modifier.size(dimens.m5))
+    }
+}
+
+
+@Composable
+fun PendingInviteItem(
+    pendingInvite: PendingInvitesUiModel,
+    userId: String,
+    onEvent: (HomeUpstreamEvent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier.fillMaxWidth(1f),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            stringResource(R.string.profile_dialog_invitation_prefix, pendingInvite.householdName),
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+    Row(
+        modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        Button(
+            onClick = {
+                onEvent(HouseholdInviteTap(
+                    pendingInvite.householdId,
+                    pendingInvite.householdName,
+                    userId,
+                    true
+                ))
+            }
+        ) {
+            Text(
+                stringResource(R.string.profile_dialog_accept_invitation),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        TextButton(
+            onClick = {
+                onEvent(HouseholdInviteTap(
+                    pendingInvite.householdId,
+                    pendingInvite.householdName,
+                    userId,
+                    false
+                ))
+            }
+        ) {
+            Text(
+                stringResource(R.string.profile_dialog_reject_invitation),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/section11/expenselens/ui/home/event/HomeUpstreamEvent.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/event/HomeUpstreamEvent.kt
@@ -10,7 +10,12 @@ sealed class HomeUpstreamEvent : UpstreamUiEvent() {
         val userId: String,
         val householdName: String
     ) : HomeUpstreamEvent()
-    data class HouseholdInviteTap(val id: String, val accepted: Boolean) : HomeUpstreamEvent()
+    data class HouseholdInviteTap(
+        val householdId: String,
+        val householdName: String,
+        val userId: String,
+        val accepted: Boolean
+    ) : HomeUpstreamEvent()
 }
 
 sealed class ProfileDialogEvents: HomeUpstreamEvent() {

--- a/app/src/main/java/com/section11/expenselens/ui/home/mapper/HomeScreenUiMapper.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/mapper/HomeScreenUiMapper.kt
@@ -1,20 +1,12 @@
 package com.section11.expenselens.ui.home.mapper
 
-import androidx.compose.ui.graphics.Color
 import com.section11.expenselens.R
-import com.section11.expenselens.domain.exceptions.UserNotFoundException
 import com.section11.expenselens.domain.models.HouseholdInvite
-import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Accepted
-import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Pending
-import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Rejected
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.models.UserHousehold
 import com.section11.expenselens.framework.utils.ResourceProvider
 import com.section11.expenselens.ui.home.HomeViewModel.HomeUiState.UserSignedIn
 import com.section11.expenselens.ui.home.HomeViewModel.HomeUiState.UserSignedIn.HouseholdUiState
-import com.section11.expenselens.ui.home.dialog.DialogUiEvent.HouseholdInviteResultEvent
-import com.section11.expenselens.ui.home.model.InviteStatusUiModel
-import com.section11.expenselens.ui.home.model.PendingInvitesUiModel
 import com.section11.expenselens.ui.home.model.UserInfoUiModel
 import javax.inject.Inject
 
@@ -41,62 +33,12 @@ class HomeScreenUiMapper @Inject constructor(private val resourceProvider: Resou
         )
     }
 
-    private fun List<HouseholdInvite>?.toPendingInvitesUiModel(): List<PendingInvitesUiModel> {
-        val pendingInvites = mutableListOf<PendingInvitesUiModel>()
-        this?.map {
-            pendingInvites.add(
-                PendingInvitesUiModel(
-                    id = it.householdId,
-                    householdName = it.householdName,
-                    timestamp = it.timestamp,
-                    status = when(it.status) {
-                        Pending -> InviteStatusUiModel.Pending
-                        Accepted -> InviteStatusUiModel.Accepted
-                        Rejected -> InviteStatusUiModel.Rejected
-                    }
-                )
-            )
-        }
-        return pendingInvites
-    }
-
     fun getSignOutSuccessMessage(): String {
         return resourceProvider.getString(R.string.home_screen_sign_out_success)
     }
 
     fun getHouseholdCreationErrorMessage(): String {
         return resourceProvider.getString(R.string.home_screen_household_creation_failure)
-    }
-
-    fun getHouseholdInviteResultEvent(exception: Throwable? = null): HouseholdInviteResultEvent {
-        return if (exception != null) {
-            HouseholdInviteResultEvent(
-                getInvitationErrorMessage(exception),
-                Color.Red
-            )
-        } else {
-            HouseholdInviteResultEvent(
-                getSuccessInvitationMessage(),
-                Color.Green
-            )
-        }
-    }
-
-    private fun getInvitationErrorMessage(throwable: Throwable): String {
-        return when(throwable) {
-            is UserNotFoundException -> {
-                resourceProvider.getString(R.string.home_screen_household_invite_user_not_found)
-            }
-            else -> getGenericInviteError()
-        }
-    }
-
-    private fun getGenericInviteError(): String {
-        return resourceProvider.getString(R.string.home_screen_household_invite_failure)
-    }
-
-    private fun getSuccessInvitationMessage(): String {
-        return resourceProvider.getString(R.string.home_screen_household_invite_success)
     }
 
     fun updateSignedInUiWithHousehold(

--- a/app/src/main/java/com/section11/expenselens/ui/home/mapper/PendingInvitationsMapper.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/mapper/PendingInvitationsMapper.kt
@@ -1,0 +1,99 @@
+package com.section11.expenselens.ui.home.mapper
+
+import androidx.compose.ui.graphics.Color
+import com.section11.expenselens.R
+import com.section11.expenselens.domain.exceptions.UserNotFoundException
+import com.section11.expenselens.domain.models.HouseholdInvite
+import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Accepted
+import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Pending
+import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Rejected
+import com.section11.expenselens.domain.models.UserHousehold
+import com.section11.expenselens.framework.utils.ResourceProvider
+import com.section11.expenselens.ui.home.HomeViewModel.HomeUiState.UserSignedIn
+import com.section11.expenselens.ui.home.HomeViewModel.HomeUiState.UserSignedIn.HouseholdUiState
+import com.section11.expenselens.ui.home.dialog.DialogUiEvent.HouseholdInviteResultEvent
+import com.section11.expenselens.ui.home.event.HomeUpstreamEvent.HouseholdInviteTap
+import com.section11.expenselens.ui.home.model.InviteStatusUiModel
+import com.section11.expenselens.ui.home.model.PendingInvitesUiModel
+import com.section11.expenselens.ui.utils.UiState
+import javax.inject.Inject
+
+class PendingInvitationsMapper @Inject constructor(private val resourceProvider: ResourceProvider) {
+
+    fun getHouseholdInviteResultEvent(exception: Throwable? = null): HouseholdInviteResultEvent {
+        return if (exception != null) {
+            HouseholdInviteResultEvent(
+                getInvitationErrorMessage(exception),
+                Color.Red
+            )
+        } else {
+            HouseholdInviteResultEvent(
+                getSuccessInvitationMessage(),
+                Color.Green
+            )
+        }
+    }
+
+    private fun getInvitationErrorMessage(throwable: Throwable): String {
+        return when(throwable) {
+            is UserNotFoundException -> {
+                resourceProvider.getString(R.string.home_screen_household_invite_user_not_found)
+            }
+            else -> getGenericInviteError()
+        }
+    }
+
+    private fun getGenericInviteError(): String {
+        return resourceProvider.getString(R.string.home_screen_household_invite_failure)
+    }
+
+    private fun getSuccessInvitationMessage(): String {
+        return resourceProvider.getString(R.string.home_screen_household_invite_success)
+    }
+
+    fun updateInvitesAndHousehold(
+        userSignedInState: UserSignedIn,
+        newPendingInvites: List<HouseholdInvite>?,
+        household: UserHousehold?
+    ): UserSignedIn {
+        return userSignedInState.copy(
+            householdInfo = household?.let { HouseholdUiState(it.id, it.name) },
+            user = userSignedInState.user.copy(
+                pendingInvites = newPendingInvites.toPendingInvitesUiModel()
+            )
+        )
+    }
+
+    fun setPendingInviteLoading(uiState: UiState, inviteTap: HouseholdInviteTap): UiState {
+        return if (uiState is UserSignedIn) {
+            val indexOfLoadingItem = uiState.user.pendingInvites.indexOfFirst { invitesUiModel ->
+                invitesUiModel.householdId == inviteTap.householdId
+            }
+            val pendingInvites = uiState.user.pendingInvites.toMutableList()
+            pendingInvites[indexOfLoadingItem] =
+                pendingInvites[indexOfLoadingItem].copy(isLoading = true)
+            uiState.copy(user = uiState.user.copy(pendingInvites = pendingInvites))
+        } else {
+            uiState
+        }
+    }
+}
+
+fun List<HouseholdInvite>?.toPendingInvitesUiModel(): List<PendingInvitesUiModel> {
+    val pendingInvites = mutableListOf<PendingInvitesUiModel>()
+    this?.map {
+        pendingInvites.add(
+            PendingInvitesUiModel(
+                householdId = it.householdId,
+                householdName = it.householdName,
+                timestamp = it.timestamp,
+                status = when(it.status) {
+                    Pending -> InviteStatusUiModel.Pending
+                    Accepted -> InviteStatusUiModel.Accepted
+                    Rejected -> InviteStatusUiModel.Rejected
+                }
+            )
+        )
+    }
+    return pendingInvites
+}

--- a/app/src/main/java/com/section11/expenselens/ui/home/model/UserInfoUiModel.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/home/model/UserInfoUiModel.kt
@@ -14,10 +14,11 @@ data class UserInfoUiModel(
 
 @Parcelize
 data class PendingInvitesUiModel(
-    val id: String,
+    val householdId: String,
     val householdName: String,
     val timestamp: Timestamp?,
-    val status: InviteStatusUiModel
+    val status: InviteStatusUiModel,
+    val isLoading: Boolean = false
 ) : Parcelable
 
 @Parcelize

--- a/app/src/main/java/com/section11/expenselens/ui/review/ExpenseReviewViewModel.kt
+++ b/app/src/main/java/com/section11/expenselens/ui/review/ExpenseReviewViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.section11.expenselens.domain.models.SuggestedExpenseInformation
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
-import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
+import com.section11.expenselens.domain.usecase.HouseholdUseCase
 import com.section11.expenselens.framework.navigation.NavigationManager
 import com.section11.expenselens.framework.navigation.NavigationManager.NavigationEvent.NavigateHome
 import com.section11.expenselens.ui.review.ExpenseReviewViewModel.ExpenseReviewUiState.ShowExpenseReview
@@ -39,7 +39,7 @@ private const val SUBMIT_EXPENSE_ERROR = "Couldn't submit expense, try again lat
 @HiltViewModel
 class ExpenseReviewViewModel @Inject constructor(
     private val expenseReviewUiMapper: ExpenseReviewScreenUiMapper,
-    private val storeExpenseUseCase: StoreExpenseUseCase,
+    private val householdUseCase: HouseholdUseCase,
     private val signInUseCase: GoogleSignInUseCase,
     private val navigationManager: NavigationManager,
     private val expenseValidator: ExpenseValidator,
@@ -81,7 +81,7 @@ class ExpenseReviewViewModel @Inject constructor(
                             _uiEvent.emit(ShowSnackBar(getFieldValidationErrorMessage(it)))
                         }
                         consolidateExpenseResult.onSuccess { expense ->
-                            val result = storeExpenseUseCase.addExpense(user, expense)
+                            val result = householdUseCase.addExpenseToCurrentHousehold(user, expense)
                             handleExpenseSubmission(result)
                         }
                     } else {

--- a/app/src/test/java/com/section11/expenselens/data/mapper/HouseholdMapperKtTest.kt
+++ b/app/src/test/java/com/section11/expenselens/data/mapper/HouseholdMapperKtTest.kt
@@ -1,0 +1,23 @@
+package com.section11.expenselens.data.mapper
+
+import org.junit.Test
+
+
+class HouseholdMapperKtTest {
+
+    @Test
+    fun `test mapToHouseholdsList`() {
+        val list = listOf(
+            mapOf("id" to "1", "name" to "Household 1"),
+            mapOf("id" to "2", "name" to "Household 2")
+        )
+
+        val households = list.mapToHouseholdsList()
+
+        assert(households.size == 2)
+        assert(households[0].id == "1")
+        assert(households[0].name == "Household 1")
+        assert(households[1].id == "2")
+        assert(households[1].name == "Household 2")
+    }
+}

--- a/app/src/test/java/com/section11/expenselens/data/repository/FirestoreHouseholdRepositoryTest.kt
+++ b/app/src/test/java/com/section11/expenselens/data/repository/FirestoreHouseholdRepositoryTest.kt
@@ -29,16 +29,16 @@ private const val HOUSEHOLD_COLLECTION = "households"
 private const val EXPENSES_COLLECTION = "expenses"
 
 @ExperimentalCoroutinesApi
-class FirestoreExpensesRepositoryTest {
+class FirestoreHouseholdRepositoryTest {
 
-    private lateinit var repository: FirestoreExpensesRepository
+    private lateinit var repository: FirestoreHouseholdRepository
     private val mockFirestore: FirebaseFirestore = mock()
     private val mockCollection: CollectionReference = mock()
     private val mockDocument: DocumentReference = mock()
 
     @Before
     fun setUp() {
-        repository = FirestoreExpensesRepository(mockFirestore)
+        repository = FirestoreHouseholdRepository(mockFirestore)
     }
 
     @Test

--- a/app/src/test/java/com/section11/expenselens/domain/usecase/HouseholdInvitationUseCaseTest.kt
+++ b/app/src/test/java/com/section11/expenselens/domain/usecase/HouseholdInvitationUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.section11.expenselens.domain.repository.HouseholdInvitationRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 class HouseholdInvitationUseCaseTest {
@@ -35,5 +36,46 @@ class HouseholdInvitationUseCaseTest {
 
         // Then
         verify(invitationsRepository).getPendingInvitations(userId)
+    }
+
+    @Test
+    fun `handleHouseholdInviteResponse is accepted should call the repository`() = runTest {
+        // Given
+        val inviteWasAccepted = true
+        val userId = "userId"
+        val householdId = "householdId"
+        val householdName = "householdName"
+
+        // When
+        householdInvitationUseCase.handleHouseholdInviteResponse(inviteWasAccepted, userId, householdId, householdName)
+
+        // Then
+        verify(invitationsRepository).acceptHouseholdInvite(userId, householdId, householdName)
+        verify(invitationsRepository, never()).deleteHouseholdInvite(userId, householdId)
+    }
+
+    @Test
+    fun `handleHouseholdInviteResponse is refused should call delete on the repository`() = runTest {
+        // Given
+        val inviteWasAccepted = false
+        val userId = "userId"
+        val householdId = "householdId"
+        val householdName = "householdName"
+
+        // When
+        householdInvitationUseCase.handleHouseholdInviteResponse(
+            inviteWasAccepted,
+            userId,
+            householdId,
+            householdName
+        )
+
+        // Then
+        verify(invitationsRepository, never()).acceptHouseholdInvite(
+            userId,
+            householdId,
+            householdName
+        )
+        verify(invitationsRepository).deleteHouseholdInvite(userId, householdId)
     }
 }

--- a/app/src/test/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModelTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/history/ExpenseHistoryViewModelTest.kt
@@ -4,7 +4,7 @@ import com.section11.expenselens.data.dto.FirestoreExpense
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.models.UserHousehold
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
-import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
+import com.section11.expenselens.domain.usecase.HouseholdUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -24,7 +24,7 @@ import org.mockito.kotlin.whenever
 class ExpenseHistoryViewModelTest {
 
     private lateinit var viewModel: ExpenseHistoryViewModel
-    private val storeExpensesUseCase: StoreExpenseUseCase = mock()
+    private val householdUseCase: HouseholdUseCase = mock()
     private val signInUseCase: GoogleSignInUseCase = mock()
     private val userData: UserData = mock()
     private val dispatcher = StandardTestDispatcher()
@@ -53,13 +53,13 @@ class ExpenseHistoryViewModelTest {
             FirestoreExpense("Transport", 50.0, mock(), "user123", "Taxi")
         )
 
-        whenever(storeExpensesUseCase.getCurrentHousehold("user123"))
+        whenever(householdUseCase.getCurrentHousehold("user123"))
             .thenReturn(userHouseHold)
-        whenever(storeExpensesUseCase.getAllExpensesFromHousehold(householdId))
+        whenever(householdUseCase.getAllExpensesFromHousehold(householdId))
             .thenReturn(Result.success(expenses))
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
+        viewModel = ExpenseHistoryViewModel(householdUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then
@@ -69,11 +69,11 @@ class ExpenseHistoryViewModelTest {
     @Test
     fun `uiState remains empty when household does not exist`() = runTest {
         // Given
-        whenever(storeExpensesUseCase.getCurrentHousehold("user123"))
+        whenever(householdUseCase.getCurrentHousehold("user123"))
             .thenReturn(null)
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
+        viewModel = ExpenseHistoryViewModel(householdUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then
@@ -86,7 +86,7 @@ class ExpenseHistoryViewModelTest {
         whenever(signInUseCase.getCurrentUser()).thenReturn(null)
 
         // When
-        viewModel = ExpenseHistoryViewModel(storeExpensesUseCase, signInUseCase, dispatcher)
+        viewModel = ExpenseHistoryViewModel(householdUseCase, signInUseCase, dispatcher)
         advanceUntilIdle()
 
         // Then

--- a/app/src/test/java/com/section11/expenselens/ui/home/mapper/HomeScreenUiMapperTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/home/mapper/HomeScreenUiMapperTest.kt
@@ -1,8 +1,6 @@
 package com.section11.expenselens.ui.home.mapper
 
-import androidx.compose.ui.graphics.Color
 import com.section11.expenselens.R
-import com.section11.expenselens.domain.exceptions.UserNotFoundException
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.models.UserHousehold
 import com.section11.expenselens.framework.utils.ResourceProvider
@@ -71,42 +69,5 @@ class HomeScreenUiMapperTest {
         mapper.getHouseholdCreationErrorMessage()
 
         verify(resourceProvider).getString(R.string.home_screen_household_creation_failure)
-    }
-
-    @Test
-    fun `getHouseholdInviteResultEvent should return correct error message when UserNotFoundException`() {
-        val userNotFoundException = UserNotFoundException("message")
-        whenever(resourceProvider.getString(R.string.home_screen_household_invite_user_not_found))
-            .thenReturn("message")
-
-        val result = mapper.getHouseholdInviteResultEvent(userNotFoundException)
-
-        verify(resourceProvider).getString(R.string.home_screen_household_invite_user_not_found)
-        assertEquals("message", result.message)
-        assertEquals(Color.Red, result.textColor)
-    }
-
-    @Test
-    fun `getInvitationErrorMessage should return correct error message when other exception`() {
-        val exception = Exception("message")
-        whenever(resourceProvider.getString(R.string.home_screen_household_invite_failure))
-            .thenReturn("message")
-
-        val result = mapper.getHouseholdInviteResultEvent(exception)
-
-        verify(resourceProvider).getString(R.string.home_screen_household_invite_failure)
-        assertEquals("message", result.message)
-    }
-
-    @Test
-    fun `getSuccessInvitationMessage should return correct success message`() {
-        whenever(resourceProvider.getString(R.string.home_screen_household_invite_success))
-            .thenReturn("message")
-
-        val result = mapper.getHouseholdInviteResultEvent()
-
-        verify(resourceProvider).getString(R.string.home_screen_household_invite_success)
-        assertEquals("message", result.message)
-        assertEquals(Color.Green, result.textColor)
     }
 }

--- a/app/src/test/java/com/section11/expenselens/ui/home/mapper/PendingInvitationsMapperTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/home/mapper/PendingInvitationsMapperTest.kt
@@ -1,0 +1,183 @@
+package com.section11.expenselens.ui.home.mapper
+
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.Timestamp
+import com.section11.expenselens.R
+import com.section11.expenselens.domain.exceptions.UserNotFoundException
+import com.section11.expenselens.domain.models.HouseholdInvite
+import com.section11.expenselens.domain.models.HouseholdInvite.HouseholdInviteStatus.Pending
+import com.section11.expenselens.domain.models.UserHousehold
+import com.section11.expenselens.framework.utils.ResourceProvider
+import com.section11.expenselens.ui.home.HomeViewModel.HomeUiState.UserSignedIn
+import com.section11.expenselens.ui.home.event.HomeUpstreamEvent.HouseholdInviteTap
+import com.section11.expenselens.ui.home.model.InviteStatusUiModel
+import com.section11.expenselens.ui.home.model.PendingInvitesUiModel
+import com.section11.expenselens.ui.home.model.UserInfoUiModel
+import junit.framework.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+class PendingInvitationsMapperTest {
+
+    private val resourceProvider: ResourceProvider = mock()
+
+    private lateinit var mapper: PendingInvitationsMapper
+
+    @Before
+    fun setup() {
+        mapper = PendingInvitationsMapper(resourceProvider)
+    }
+
+    @Test
+    fun `getHouseholdInviteResultEvent should return correct error message when UserNotFoundException`() {
+        val userNotFoundException = UserNotFoundException("message")
+        whenever(resourceProvider.getString(R.string.home_screen_household_invite_user_not_found))
+            .thenReturn("message")
+
+        val result = mapper.getHouseholdInviteResultEvent(userNotFoundException)
+
+        verify(resourceProvider).getString(R.string.home_screen_household_invite_user_not_found)
+        assertEquals("message", result.message)
+        assertEquals(Color.Red, result.textColor)
+    }
+
+    @Test
+    fun `getInvitationErrorMessage should return correct error message when other exception`() {
+        val exception = Exception("message")
+        whenever(resourceProvider.getString(R.string.home_screen_household_invite_failure))
+            .thenReturn("message")
+
+        val result = mapper.getHouseholdInviteResultEvent(exception)
+
+        verify(resourceProvider).getString(R.string.home_screen_household_invite_failure)
+        assertEquals("message", result.message)
+    }
+
+    @Test
+    fun `getSuccessInvitationMessage should return correct success message`() {
+        whenever(resourceProvider.getString(R.string.home_screen_household_invite_success))
+            .thenReturn("message")
+
+        val result = mapper.getHouseholdInviteResultEvent()
+
+        verify(resourceProvider).getString(R.string.home_screen_household_invite_success)
+        assertEquals("message", result.message)
+        assertEquals(Color.Green, result.textColor)
+    }
+
+    @Test
+    fun `updateInvitesAndHousehold should return user with updated pending invites`() {
+        val userSignedInState = UserSignedIn(
+            greeting = "greeting",
+            user = UserInfoUiModel(
+                id = "user123",
+                displayName = "John Doe",
+                profilePic = "profilePic",
+                pendingInvites = listOf(
+                    PendingInvitesUiModel(
+                        householdId = "household456",
+                        householdName = "Test Household",
+                        timestamp = Timestamp.now(),
+                        status = InviteStatusUiModel.Pending,
+                        isLoading = false
+                    )
+                )
+            ),
+            householdInfo = UserSignedIn.HouseholdUiState("id", "name")
+        )
+
+        val result = mapper.updateInvitesAndHousehold(userSignedInState, emptyList(), null)
+
+        assertThat(result.user.pendingInvites).isEmpty()
+    }
+
+    @Test
+    fun `updateInvitesAndHousehold should return user with updated pending invites and household`() {
+        val householdId = "household456"
+        val userSignedInState = UserSignedIn(
+            greeting = "greeting",
+            user = UserInfoUiModel(
+                id = "user123",
+                displayName = "John Doe",
+                profilePic = "profilePic",
+                pendingInvites = emptyList()
+            )
+        )
+        val newHousehold = UserHousehold(householdId, "Test Household")
+        val newInvites = listOf(
+            HouseholdInvite(
+                householdId = householdId,
+                householdName = "Test Household",
+                inviterId = "inviterId",
+                timestamp = Timestamp.now(),
+                status = Pending,
+            )
+        )
+
+        val result = mapper.updateInvitesAndHousehold(userSignedInState, newInvites, newHousehold)
+
+        assertThat(result.user.pendingInvites).isNotEmpty()
+        assertThat(result.householdInfo).isNotNull()
+        assertThat(result.householdInfo?.id).isEqualTo(householdId)
+        assertThat(result.user.pendingInvites.first().householdId).isEqualTo(householdId)
+    }
+
+    @Test
+    fun `setPendingInviteLoading should return user with pending invite loading`() {
+        val householdId = "household456"
+        val householdName = "Test Household"
+        val userSignedInState = UserSignedIn(
+            greeting = "greeting",
+            user = UserInfoUiModel(
+                id = "user123",
+                displayName = "John Doe",
+                profilePic = "profilePic",
+                pendingInvites = listOf(
+                    PendingInvitesUiModel(
+                        householdId = householdId,
+                        householdName = householdName,
+                        timestamp = Timestamp.now(),
+                        status = InviteStatusUiModel.Pending,
+                        isLoading = false
+                    )
+                )
+            )
+        )
+
+        val inviteTap = HouseholdInviteTap(householdId, householdName, "userId", true)
+
+        val result = mapper.setPendingInviteLoading(userSignedInState, inviteTap)
+
+        assertThat(result as UserSignedIn).isNotNull()
+        assertThat(result.user.pendingInvites.first().isLoading).isTrue()
+    }
+
+    @Test
+    fun `toPendingInvitesUiModel should return correct list of pending invites`() {
+        val householdId = "household456"
+        val householdName = "Test Household"
+        val timestamp = Timestamp(Date())
+        val pendingInvites = listOf(
+            HouseholdInvite(
+                householdId = householdId,
+                householdName = householdName,
+                inviterId = "inviterId",
+                timestamp = timestamp,
+                status = Pending,
+            )
+        )
+
+        val result = pendingInvites.toPendingInvitesUiModel()
+
+        assertThat(result.first().householdId).isEqualTo(householdId)
+        assertThat(result.first().householdName).isEqualTo(householdName)
+        assertThat(result.first().timestamp).isEqualTo(timestamp)
+        assertThat(result.first().status).isEqualTo(InviteStatusUiModel.Pending)
+        assertThat(result.first().isLoading).isFalse()
+    }
+}

--- a/app/src/test/java/com/section11/expenselens/ui/review/ExpenseReviewViewModelTest.kt
+++ b/app/src/test/java/com/section11/expenselens/ui/review/ExpenseReviewViewModelTest.kt
@@ -5,7 +5,7 @@ import com.section11.expenselens.domain.models.ConsolidatedExpenseInformation
 import com.section11.expenselens.domain.models.SuggestedExpenseInformation
 import com.section11.expenselens.domain.models.UserData
 import com.section11.expenselens.domain.usecase.GoogleSignInUseCase
-import com.section11.expenselens.domain.usecase.StoreExpenseUseCase
+import com.section11.expenselens.domain.usecase.HouseholdUseCase
 import com.section11.expenselens.framework.navigation.NavigationManager
 import com.section11.expenselens.framework.navigation.NavigationManager.NavigationEvent.NavigateHome
 import com.section11.expenselens.ui.review.ExpenseReviewViewModel.ExpenseReviewUiState.ShowExpenseReview
@@ -44,7 +44,7 @@ private const val UNAUTHENTICATED_ERROR = "Authentication Error occurred, please
 class ExpenseReviewViewModelTest {
 
     private val expenseReviewUiMapper: ExpenseReviewScreenUiMapper = mock()
-    private val storeExpenseUseCase: StoreExpenseUseCase = mock()
+    private val householdUseCase: HouseholdUseCase = mock()
     private val signInUseCase: GoogleSignInUseCase = mock()
     private val navigationManager: NavigationManager = mock()
     private val expenseValidator: ExpenseValidator = mock()
@@ -58,7 +58,7 @@ class ExpenseReviewViewModelTest {
 
         viewModel = ExpenseReviewViewModel(
             expenseReviewUiMapper,
-            storeExpenseUseCase,
+            householdUseCase,
             signInUseCase,
             navigationManager,
             expenseValidator,
@@ -194,12 +194,12 @@ class ExpenseReviewViewModelTest {
         val expense = mock<ConsolidatedExpenseInformation>()
         val userMock = mockUserData()
         whenever(expenseValidator.validateExpense(any())).thenReturn(Result.success(expense))
-        whenever(storeExpenseUseCase.addExpense(any(), any())).thenReturn(Result.success(Unit))
+        whenever(householdUseCase.addExpenseToCurrentHousehold(any(), any())).thenReturn(Result.success(Unit))
 
         viewModel.onUpstreamEvent(ExpenseSubmitted(expenseReviewUiModel))
 
         advanceUntilIdle()
-        verify(storeExpenseUseCase).addExpense(userMock, expense)
+        verify(householdUseCase).addExpenseToCurrentHousehold(userMock, expense)
         verify(navigationManager).navigate(NavigateHome)
     }
 
@@ -212,7 +212,7 @@ class ExpenseReviewViewModelTest {
         )
         val expense = mock<ConsolidatedExpenseInformation>()
         whenever(expenseValidator.validateExpense(any())).thenReturn(Result.success(expense))
-        whenever(storeExpenseUseCase.addExpense(any(), any())).thenReturn(Result.success(Unit))
+        whenever(householdUseCase.addExpenseToCurrentHousehold(any(), any())).thenReturn(Result.success(Unit))
 
         // Since this is a cold flow we need to start the collection before actually calling the viewModel method
         val job = launch {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ textRecognition = "16.0.1"
 kotlinx-coroutines = "1.10.0"
 google-services = "4.4.2"
 truthVersion = "1.4.4"
+uiTestJunit4 = "1.7.8"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -79,6 +80,7 @@ play-services-identity = { module = "com.google.android.gms:play-services-identi
 play-services-auth-api-phone = { module = "com.google.android.gms:play-services-auth-api-phone", version.ref = "playServicesAuthApiPhone" }
 retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitVersion" }
 text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "textRecognition" }
+ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "uiTestJunit4" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- The user can now accept/refuse and join a household
- Refactored how firestore constants are structure, to reflect firestore structure and make future repositories easier to implement
- Added tests for new classes and new functionalities
- Renamed expensesUseCase to HouseholdUseCase
- Created HouseholdInvitation useCase and repositories